### PR TITLE
feat: single-click thumbnail to toggle selection mode

### DIFF
--- a/feature/videopicker/src/main/java/one/only/player/feature/videopicker/composables/FolderItem.kt
+++ b/feature/videopicker/src/main/java/one/only/player/feature/videopicker/composables/FolderItem.kt
@@ -1,5 +1,8 @@
 package one.only.player.feature.videopicker.composables
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +20,7 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -51,6 +55,7 @@ fun FolderItem(
     isSelected: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
+    onThumbnailClick: (() -> Unit)? = null,
 ) {
     when (preferences.mediaLayoutMode) {
         MediaLayoutMode.LIST -> FolderListItem(
@@ -63,6 +68,7 @@ fun FolderItem(
             isSelected = isSelected,
             onClick = onClick,
             onLongClick = onLongClick,
+            onThumbnailClick = onThumbnailClick,
         )
         MediaLayoutMode.GRID -> FolderGridItem(
             folder = folder,
@@ -74,6 +80,7 @@ fun FolderItem(
             isSelected = isSelected,
             onClick = onClick,
             onLongClick = onLongClick,
+            onThumbnailClick = onThumbnailClick,
         )
     }
 }
@@ -90,6 +97,7 @@ private fun FolderListItem(
     isSelected: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
+    onThumbnailClick: (() -> Unit)? = null,
 ) {
     NextSegmentedListItem(
         modifier = modifier.testTag("item_folder_${folder.name}"),
@@ -113,27 +121,39 @@ private fun FolderListItem(
         onClick = onClick,
         onLongClick = onLongClick,
         leadingContent = {
-            Box(modifier = Modifier.padding(horizontal = 8.dp)) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = R.drawable.folder_thumb),
-                    contentDescription = "",
-                    tint = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    modifier = Modifier
-                        .width(min(90.dp, LocalConfiguration.current.screenWidthDp.dp * 0.3f))
-                        .aspectRatio(20 / 17f),
-                )
-
-                if (preferences.shouldShowDurationField) {
-                    InfoChip(
-                        text = Utils.formatDurationMillis(folder.mediaDuration),
-                        modifier = Modifier
-                            .padding(5.dp)
-                            .padding(bottom = 3.dp)
-                            .align(Alignment.BottomEnd),
-                        backgroundColor = Color.Black.copy(alpha = 0.6f),
-                        contentColor = Color.White,
-                        shape = MaterialTheme.shapes.extraSmall,
+            Box(
+                modifier = if (onThumbnailClick != null) {
+                    Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onThumbnailClick,
                     )
+                } else {
+                    Modifier
+                },
+            ) {
+                Box(modifier = Modifier.padding(horizontal = 8.dp)) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = R.drawable.folder_thumb),
+                        contentDescription = "",
+                        tint = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        modifier = Modifier
+                            .width(min(90.dp, LocalConfiguration.current.screenWidthDp.dp * 0.3f))
+                            .aspectRatio(20 / 17f),
+                    )
+
+                    if (preferences.shouldShowDurationField) {
+                        InfoChip(
+                            text = Utils.formatDurationMillis(folder.mediaDuration),
+                            modifier = Modifier
+                                .padding(5.dp)
+                                .padding(bottom = 3.dp)
+                                .align(Alignment.BottomEnd),
+                            backgroundColor = Color.Black.copy(alpha = 0.6f),
+                            contentColor = Color.White,
+                            shape = MaterialTheme.shapes.extraSmall,
+                        )
+                    }
                 }
             }
         },
@@ -195,6 +215,7 @@ private fun FolderGridItem(
     isSelected: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
+    onThumbnailClick: (() -> Unit)? = null,
 ) {
     NextSegmentedListItem(
         modifier = modifier
@@ -225,7 +246,17 @@ private fun FolderGridItem(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Box {
+                Box(
+                    modifier = if (onThumbnailClick != null) {
+                        Modifier.clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = onThumbnailClick,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ) {
                     Icon(
                         imageVector = ImageVector.vectorResource(id = R.drawable.folder_thumb),
                         contentDescription = "",

--- a/feature/videopicker/src/main/java/one/only/player/feature/videopicker/composables/MediaView.kt
+++ b/feature/videopicker/src/main/java/one/only/player/feature/videopicker/composables/MediaView.kt
@@ -120,6 +120,10 @@ fun MediaView(
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         selectionManager.toggleFolderSelection(folder)
                     },
+                    onThumbnailClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.VirtualKey)
+                        selectionManager.toggleFolderSelection(folder)
+                    },
                 )
             }
 
@@ -158,6 +162,10 @@ fun MediaView(
                     },
                     onLongClick = {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        selectionManager.toggleVideoSelection(video)
+                    },
+                    onThumbnailClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.VirtualKey)
                         selectionManager.toggleVideoSelection(video)
                     },
                     modifier = Modifier.onVideoFirstVisible {

--- a/feature/videopicker/src/main/java/one/only/player/feature/videopicker/composables/VideoItem.kt
+++ b/feature/videopicker/src/main/java/one/only/player/feature/videopicker/composables/VideoItem.kt
@@ -1,6 +1,8 @@
 package one.only.player.feature.videopicker.composables
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +26,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,6 +62,7 @@ fun VideoItem(
     isSelected: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
+    onThumbnailClick: (() -> Unit)? = null,
 ) {
     when (preferences.mediaLayoutMode) {
         MediaLayoutMode.LIST -> VideoListItem(
@@ -71,6 +75,7 @@ fun VideoItem(
             isSelected = isSelected,
             onClick = onClick,
             onLongClick = onLongClick,
+            onThumbnailClick = onThumbnailClick,
         )
         MediaLayoutMode.GRID -> VideoGridItem(
             video = video,
@@ -82,6 +87,7 @@ fun VideoItem(
             isSelected = isSelected,
             onClick = onClick,
             onLongClick = onLongClick,
+            onThumbnailClick = onThumbnailClick,
         )
     }
 }
@@ -98,6 +104,7 @@ private fun VideoListItem(
     isSelected: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
+    onThumbnailClick: (() -> Unit)? = null,
 ) {
     NextSegmentedListItem(
         modifier = modifier.testTag("item_video_${video.displayName}"),
@@ -121,12 +128,24 @@ private fun VideoListItem(
         onClick = onClick,
         onLongClick = onLongClick,
         leadingContent = {
-            ThumbnailView(
-                video = video,
-                preferences = preferences,
-                modifier = Modifier
-                    .width(min(150.dp, LocalConfiguration.current.screenWidthDp.dp * 0.35f)),
-            )
+            Box(
+                modifier = if (onThumbnailClick != null) {
+                    Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onThumbnailClick,
+                    )
+                } else {
+                    Modifier
+                },
+            ) {
+                ThumbnailView(
+                    video = video,
+                    preferences = preferences,
+                    modifier = Modifier
+                        .width(min(150.dp, LocalConfiguration.current.screenWidthDp.dp * 0.35f)),
+                )
+            }
         },
         content = {
             Text(
@@ -177,6 +196,7 @@ private fun VideoGridItem(
     isSelected: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
+    onThumbnailClick: (() -> Unit)? = null,
 ) {
     NextSegmentedListItem(
         modifier = modifier
@@ -206,10 +226,22 @@ private fun VideoGridItem(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                ThumbnailView(
-                    video = video,
-                    preferences = preferences,
-                )
+                Box(
+                    modifier = if (onThumbnailClick != null) {
+                        Modifier.clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = onThumbnailClick,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ) {
+                    ThumbnailView(
+                        video = video,
+                        preferences = preferences,
+                    )
+                }
                 Text(
                     text = if (preferences.shouldShowExtensionField) video.nameWithExtension else video.displayName,
                     maxLines = 2,


### PR DESCRIPTION
This change aligns the thumbnail interaction with common photo gallery
apps, where a single tap on the thumbnail enters selection mode and
toggles the item's checked state simultaneously.

The title/text area remains responsible for primary actions (play/open)
to preserve the existing user flow.