### PR TITLE
fix(videopicker): restore folder list scrolling

### DIFF
--- a/feature/videopicker/src/main/java/one/only/player/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
+++ b/feature/videopicker/src/main/java/one/only/player/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
@@ -503,7 +503,13 @@ internal fun MediaPickerScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .nestedScroll(scrollBehavior.nestedScrollConnection)
+                .then(
+                    if (shouldUseLargeTopBar) {
+                        Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+                    } else {
+                        Modifier
+                    },
+                )
                 .padding(top = scaffoldPadding.calculateTopPadding())
                 .padding(start = scaffoldPadding.calculateStartPadding(LocalLayoutDirection.current)),
         ) {


### PR DESCRIPTION
Apply the title nested scroll behavior only when the collapsible large top bar is visible.

Fixes #167 